### PR TITLE
Updating to work better with powershell7

### DIFF
--- a/CodeGenerator/InstallShowUIAssembly.ps1
+++ b/CodeGenerator/InstallShowUIAssembly.ps1
@@ -160,7 +160,7 @@ $global:addTypeParameters = @{
     Language='CSharpVersion3'
 }
 # If we're running in .Net 4, we shouldn't specify the Language, because it'll use CSharp4
-if ($PSVersionTable.ClrVersion.Major -ge 4) {
+if ($PSVersionTable.ClrVersion -eq $nothing -or $PSVersionTable.ClrVersion.Major -ge 4) {
     $AddTypeParameters.Remove("Language")
 }
 # Check to see if the outputpath can be written to: we don't *have* to save it as a dll


### PR DESCRIPTION
From the given error

Add-Type: ...\Documents\PowerShell\Modules\showui\1.5\CodeGenerator\InstallShowUIAssembly.ps1:176
Line |
 176 |  Add-Type @addTypeParameters
     |           ~~~~~~~~~~~~~~~~~~
     | Cannot bind parameter 'Language'. Cannot convert value "CSharpVersion3" to type "Microsoft.PowerShell.Commands.Language". Error: "Unable to match the identifier name CSharpVersion3 to a valid enumerator name. Specify one of the following enumerator names and try again: CSharp"